### PR TITLE
update java return type

### DIFF
--- a/encoding/java_type.go
+++ b/encoding/java_type.go
@@ -37,37 +37,35 @@ func GetArgType(v interface{}) string {
 	case nil:
 		return "V"
 	case bool:
-		return "Z"
+		return "boolean"
 	case []bool:
 		return "[Z"
 	case byte:
-		return "B"
+		return "byte"
 	case []byte:
 		return "[B"
 	case int8:
-		return "B"
+		return "byte"
 	case []int8:
 		return "[B"
 	case int16:
-		return "S"
+		return "short"
 	case []int16:
 		return "[S"
 	case uint16: // Equivalent to Char of Java
-		return "C"
+		return "char"
 	case []uint16:
 		return "[C"
-	// case rune:
-	//	return "C"
-	case int:
-		return "J"
+	case int: // Equivalent to Long of Java
+		return "long"
 	case []int:
 		return "[J"
 	case int32:
-		return "I"
+		return "int"
 	case []int32:
 		return "[I"
 	case int64:
-		return "J"
+		return "long"
 	case []int64:
 		return "[J"
 	case time.Time:
@@ -75,11 +73,11 @@ func GetArgType(v interface{}) string {
 	case []time.Time:
 		return "[Ljava.util.Date"
 	case float32:
-		return "F"
+		return "float"
 	case []float32:
 		return "[F"
 	case float64:
-		return "D"
+		return "double"
 	case []float64:
 		return "[D"
 	case string:


### PR DESCRIPTION
fix:https://github.com/apache/dubbo-go-hessian2/issues/291

使用triple协议时，java server 在pb 对type 字段 序列化时在java侧是直接使用的java method return class type。
而golang server 在对type 字段序列化时则是在使用hessian原有的return 编码。

在java client端 接收方法返回值是通过pb的type进行class.forName(type)，由于go server返回的类型是hessian的类型编码所以导致ClassNotFound异常
